### PR TITLE
Fixes for "Open with" dialog

### DIFF
--- a/src/app/qml/dialogs/OpenWithDialog.qml
+++ b/src/app/qml/dialogs/OpenWithDialog.qml
@@ -9,20 +9,33 @@ Dialog {
     text: i18n.tr("What do you want to do with the clicked file?")
     property var model
 
+    property bool previewButtonVisible: false
+    property bool extractButtonVisible: false
+
+    signal showPreview()
+    signal extractArchive()
+    signal openWith()
+    signal showProperties()
+
     Button {
         id: previewButton
         text: i18n.tr("Preview")
         color: UbuntuColors.green
+        visible: previewButtonVisible
         onClicked: {
             PopupUtils.close(dialog)
-            var props = {
-                model: model
-            }
-            if(model.mimeType.indexOf("image/") !== -1)
-            pageStack.push(Qt.resolvedUrl("../ui/ImagePreview.qml"), props)
-            else {
-                Qt.openUrlExternally("video://" + filePath)
-            }
+            showPreview()
+        }
+    }
+
+    Button {
+        id: extractButton
+        text: i18n.tr("Extract archive")
+        color: UbuntuColors.green
+        visible: extractButtonVisible
+        onClicked: {
+            PopupUtils.close(dialog)
+            extractArchive()
         }
     }
 
@@ -32,7 +45,7 @@ Dialog {
         color: UbuntuColors.green
         onClicked: {
             PopupUtils.close(dialog)
-            openLocalFile(filePath)
+            openWith()
         }
     }
 
@@ -41,7 +54,8 @@ Dialog {
         text: i18n.tr("Properties")
         color: UbuntuColors.blue
         onClicked: {
-            PopupUtils.open(Qt.resolvedUrl("../ui/FileDetailsPopover.qml"), mainView,{ "model": model })
+            PopupUtils.close(dialog)
+            showProperties()
         }
     }
 

--- a/src/app/qml/ui/FolderListPage.qml
+++ b/src/app/qml/ui/FolderListPage.qml
@@ -328,6 +328,7 @@ SidebarPageLayout {
 
         //High Level openFile() function
         //remote files are saved as temporary files and then opened
+        // TODO: This is deprecated. Should be removed, with all the actions that actually uses it.
         function openFile(model, share) {
             if (model.isRemote) {
                 //download and open later when the signal downloadTemporaryComplete() arrives

--- a/src/app/qml/views/FolderDelegateActions.qml
+++ b/src/app/qml/views/FolderDelegateActions.qml
@@ -58,7 +58,7 @@ QtObject {
 
                     var props = {
                         model: model,
-                        previewButtonVisible: model.mimeType.indexOf("image/") + model.mimeType.indexOf("audio/") + model.mimeType.indexOf("video/") > 0,
+                        previewButtonVisible: model.mimeType.indexOf("image/") + model.mimeType.indexOf("audio/") + model.mimeType.indexOf("video/") > -3,
                         extractButtonVisible: archiveType !== ""
                     }
 

--- a/src/app/qml/views/FolderDelegateActions.qml
+++ b/src/app/qml/views/FolderDelegateActions.qml
@@ -19,20 +19,21 @@ QtObject {
     }
 
     function itemClicked(model) {
-        if (model.isBrowsable) {
-            console.log("browsable path="+model.filePath+" isRemote="+model.isRemote+" needsAuthentication="+model.needsAuthentication)
+        if (model.isBrowsable) {    // Item is dir
+            console.log("browsable path=", model.filePath,
+                        "isRemote=", model.isRemote,
+                        "needsAuthentication=", model.needsAuthentication)
 
-            if(!isContentHub && fileSelectorMode)
-            {
+            if (!isContentHub && fileSelectorMode) {
                 folderModel.model.selectionObject.select(model.index,false,true)
-            } else {
+            }
 
-                if ((model.isReadable && model.isExecutable) ||
-                        (model.isRemote && model.needsAuthentication) //in this case it is necessary to generate the signal needsAuthentication()
-                        ) {
+            else {
+                var isReadableDir = model.isReadable && model.isExecutable
+                var isRemoteWithAuth = model.isRemote && model.needsAuthentication //in this case it is necessary to generate the signal needsAuthentication()
+
+                if (isReadableDir || isRemoteWithAuth) {
                     console.log("Changing to dir", model.filePath)
-
-
                     folderModel.goTo(model.filePath)
                 } else {
                     var props = {
@@ -44,21 +45,48 @@ QtObject {
                     PopupUtils.open(Qt.resolvedUrl("../dialogs/NotifyDialog.qml"), mainView, props)
                 }
             }
-        } else {
+        }
+
+        else {  // Item is file
             console.log("Non dir clicked")
+
             if (fileSelectorMode) {
                 folderModel.model.selectionObject.select(model.index,false,true)
             } else if (!folderSelectorMode){
-                var props
-                var isMedia = model.mimeType.indexOf("image/") + model.mimeType.indexOf("audio/") + model.mimeType.indexOf("video/")
-                if (isMedia !== -3)
-                {
-                    props = {
-                        model: model
+                if (model.isLocal) {    // Item is local file
+                    var archiveType = folderModel.getArchiveType(model.fileName)
+
+                    var props = {
+                        model: model,
+                        previewButtonVisible: model.mimeType.indexOf("image/") + model.mimeType.indexOf("audio/") + model.mimeType.indexOf("video/") > 0,
+                        extractButtonVisible: archiveType !== ""
                     }
-                    PopupUtils.open(Qt.resolvedUrl("../dialogs/OpenWithDialog.qml"), delegate, props)
-                } else {
-                    openFile(model)
+
+                    var popup = PopupUtils.open(Qt.resolvedUrl("../dialogs/OpenWithDialog.qml"), delegate, props)
+
+                    popup.showPreview.connect(function() {
+                        if(model.mimeType.indexOf("image/") !== -1)
+                            pageStack.push(Qt.resolvedUrl("../ui/ImagePreview.qml"), props)
+                        else {
+                            Qt.openUrlExternally("video://" + filePath)
+                        }
+                    })
+
+                    popup.extractArchive.connect(function() {
+                        folderModel.extractArchive(model.filePath, model.fileName, archiveType)
+                    })
+
+                    popup.openWith.connect(function() {
+                        openLocalFile(model.filePath)
+                    })
+
+                    popup.showProperties.connect(function() {
+                        PopupUtils.open(Qt.resolvedUrl("../ui/FileDetailsPopover.qml"), mainView,{ "model": model })
+                    })
+
+                } else {    // Item is remote file
+                    //download and open later when the signal downloadTemporaryComplete() arrives
+                    folderModel.model.downloadAsTemporaryFile(model.index)
                 }
             }
         }


### PR DESCRIPTION
- Unified 'Open with' and 'Extract' dialog.
- Always show 'Open With' dialog for any file type
- Close 'Open with' dialog when 'Properties/Details' dialog is opened
- [WARNING] Marked 'Extract' dialog for deprecation. It's still used for some action